### PR TITLE
disable Smart Quote/Dash feature on find panel

### DIFF
--- a/FindPanel/Controllers/OgreAdvancedFindPanelController.m
+++ b/FindPanel/Controllers/OgreAdvancedFindPanelController.m
@@ -134,6 +134,16 @@ static NSString	*OgreAFPCAttributedReplaceHistoryKey = @"AFPC Attributed Replace
 	[self setCloseWhenDoneOption:YES];
 	
 	[toggleStyleOptionsButton setState:NSOffState];
+    
+    // disable Smart Quote/Dash on Mavericks and later
+    if ([findTextView respondsToSelector:@selector(setAutomaticQuoteSubstitutionEnabled:)]) {
+        [findTextView setAutomaticQuoteSubstitutionEnabled:NO];
+        [replaceTextView setAutomaticQuoteSubstitutionEnabled:NO];
+    }
+    if ([findTextView respondsToSelector:@selector(setAutomaticDashSubstitutionEnabled:)]) {
+        [findTextView setAutomaticDashSubstitutionEnabled:NO];
+        [replaceTextView setAutomaticDashSubstitutionEnabled:NO];
+    }
 	
 	// restore history
 	[self restoreHistory:[textFinder history]];


### PR DESCRIPTION
This new feature substitutes automatically normal quote (") and dash (') symbols with another symbols that are also quote/dash symbol but with an angle, and it is automatically enabled in all NSTextView (and its subclass) if it is build on 10.9.

We know user can disable this feature on the System Preferences system-wide.  However most of average users don't know about it.  Considering the purpose of OgreKit find panel, this feature has less advantages, but just makes user confused.

So I think it's better to disable it on OgreKit find panel.
