### PR TITLE
Mod search window to not close with return key

### DIFF
--- a/FindPanel/Controllers/OgreAdvancedFindPanelController.m
+++ b/FindPanel/Controllers/OgreAdvancedFindPanelController.m
@@ -1692,7 +1692,12 @@ static NSString	*OgreAFPCAttributedReplaceHistoryKey = @"AFPC Attributed Replace
 #endif
 	
 	if (aSelector == @selector(insertNewline:)) {
-		[findNextButton setAction:@selector(findNextAndOrderOut:)];
+        if (([[NSApp currentEvent] modifierFlags] & NSShiftKeyMask) == NSShiftKeyMask) {
+            [findNextButton setAction:@selector(findNextAndOrderOut:)];
+        } else {
+            [findNextButton setAction:@selector(findNext:)];
+        }
+        
 		[findNextButton performClick:self]; // Find Next
 		[findNextButton setAction:@selector(findNext:)];
 		//[self findNextAndOrderOut:self];


### PR DESCRIPTION
Currently, OgreKit's search window closes automatically when search next command is invoked using return key. We changed this behavior to close the search window only if return key is pressed with shift key. Otherwise just perform search next and the search window remains open.

This fix is based on the following blog article by @aki-null:
http://blog.aki-null.net/blog/2011/10/21/coteditor/
