### PR TITLE
自動置換機能をデフォルトで停止

### DIFF
--- a/FindPanel/Controllers/OgreAdvancedFindPanelController.m
+++ b/FindPanel/Controllers/OgreAdvancedFindPanelController.m
@@ -134,6 +134,17 @@ static NSString	*OgreAFPCAttributedReplaceHistoryKey = @"AFPC Attributed Replace
 	[self setCloseWhenDoneOption:YES];
 	
 	[toggleStyleOptionsButton setState:NSOffState];
+    
+	// 自動置換機能を停止
+	[@[findTextView, replaceTextView] enumerateObjectsUsingBlock:^(id textView, NSUInteger idx, BOOL *stop) {
+		[textView setSmartInsertDeleteEnabled:NO];
+		[textView setAutomaticDashSubstitutionEnabled:NO];
+		[textView setAutomaticDataDetectionEnabled:NO];
+		[textView setAutomaticLinkDetectionEnabled:NO];
+		[textView setAutomaticQuoteSubstitutionEnabled:NO];
+		[textView setAutomaticSpellingCorrectionEnabled:NO];
+		[textView setAutomaticTextReplacementEnabled:NO];
+	}];
 	
 	// restore history
 	[self restoreHistory:[textFinder history]];


### PR DESCRIPTION
Mavericks以降，「スマートダッシュ記号」「スマート引用符」といった自動置換機能がデフォルトで有効になるようになりました。
検索・置換パネルにおいては，入力文字を勝手に置換されるのは困るので，このような置換機能をデフォルトで一律にOFFにするよう変更しました。
- スマートコピー／ペースト
- スマート引用符
- スマートダッシュ記号
- スマートリンク
- データ検出
- テキストの置換
- スペルの自動修正

をデフォルトで無効化します。
