### PR TITLE
Find Panelが現在のDesktop Spaceに表示されるように修正

### DIFF
--- a/FindPanel/Controllers/OgreFindPanelController.m
+++ b/FindPanel/Controllers/OgreFindPanelController.m
@@ -21,6 +21,7 @@
 	/* 前回のFind Panelの位置を再現 */
     [[self findPanel] setFrameAutosaveName: @"Find Panel"];
     [[self findPanel] setFrameUsingName: @"Find Panel"];
+    [[self findPanel] setCollectionBehavior:NSWindowCollectionBehaviorMoveToActiveSpace]; // 現在表示中のDesktop SpaceにFind Panelを表示
 }
 
 - (OgreTextFinder*)textFinder


### PR DESCRIPTION
Spaces (Mission Control) の機能で複数のデスクトップスペースを使っているとき，検索パネルとドキュメントウィンドウが別のスペースに存在する場合，ドキュメントウィンドウ側でCommand+Fを押すと，検索パネルが存在するスペースに飛んでしまいます。
特に，マルチドキュメントアプリケーションで，複数のドキュメントを別々のデスクトップスペースで編集している場合に，この問題が顕在化し，意図しないデスクトップスペースのジャンプが起こってしまいます。
そこで，Command+Fで呼び出されたときに，常に現在のデスクトップスペースで検索パネルが表示されるよう修正しました。
