### PR TITLE
Avoid applying rich text to text views in find panel

### DIFF
--- a/FindPanel/Controllers/OgreAdvancedFindPanelController.m
+++ b/FindPanel/Controllers/OgreAdvancedFindPanelController.m
@@ -910,6 +910,8 @@ static NSString	*OgreAFPCAttributedReplaceHistoryKey = @"AFPC Attributed Replace
 			[self toggleStyleOptions:self];
 		}
 		[toggleStyleOptionsButton setHidden:YES];
+        [findTextView setRichText:NO];
+        [replaceTextView setRichText:NO];
 	} else {
 		[toggleStyleOptionsButton setHidden:NO];
 	}


### PR DESCRIPTION
検索パネルで `useStylesInFindPanel` が `NO` のときはパネル内の text view のスタイルも切るようにしました。
